### PR TITLE
disable message to use anonymous object instead of lambda

### DIFF
--- a/src/main/kotlin/fr/stardustenterprises/gradle/rust/importer/ImporterPlugin.kt
+++ b/src/main/kotlin/fr/stardustenterprises/gradle/rust/importer/ImporterPlugin.kt
@@ -3,6 +3,8 @@ package fr.stardustenterprises.gradle.rust.importer
 import fr.stardustenterprises.gradle.rust.importer.ProcessResourcesRust.process
 import fr.stardustenterprises.gradle.rust.importer.ext.ImporterExtension
 import fr.stardustenterprises.stargrad.StargradPlugin
+import org.gradle.api.Action
+import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.language.jvm.tasks.ProcessResources
 
@@ -30,9 +32,14 @@ class ImporterPlugin : StargradPlugin() {
                 it.configure { t ->
                     t.from(configuration)
                 }
-            }.get().doLast {
-                val baseDir = (it as ProcessResources).destinationDir
-                process(project, importerExtension, baseDir)
             }
+            .get()
+            // Use anonymous object instead of lambda to avoid message disabling execution optimizations
+            .doLast(object : Action<Task> {
+                override fun execute(t: Task) {
+                    val baseDir = (t as ProcessResources).destinationDir
+                    process(project, importerExtension, baseDir)
+                }
+            })
     }
 }


### PR DESCRIPTION
I have this message when running build task.

> > Task :<project-name>:processResources
> Execution optimizations have been disabled for task ':<project-name>:processResources' to ensure correctness due to the following reasons:
>   - Additional action of task ':<project-name>:processResources' was implemented by the Java lambda 'fr.stardustenterprises.gradle.rust.importer.ImporterPlugin$$Lambda$5599/0x00000008029de430'. Reason: Using Java lambdas is not supported as task inputs. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implementation_unknown for more details about this problem.
> Additional action of task ':<project-name>:processResources' was implemented by the Java lambda 'fr.stardustenterprises.gradle.rust.importer.ImporterPlugin$$Lambda$5599/0x00000008029de430'. Reason: Using Java lambdas is not supported as task inputs. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implementation_unknown for more details about this problem. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. Execution optimizations are disabled to ensure correctness. See https://docs.gradle.org/7.4.2/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.

The way to avoid to this message I found is that not use lambda in doLast task.
See https://github.com/gradle/gradle/issues/5510#issuecomment-416860213