### PR TITLE
Fix Windows error

### DIFF
--- a/src/main/kotlin/fr/stardustenterprises/gradle/rust/wrapper/task/BuildTask.kt
+++ b/src/main/kotlin/fr/stardustenterprises/gradle/rust/wrapper/task/BuildTask.kt
@@ -210,6 +210,7 @@ open class BuildTask : ConfigurableTask<WrapperExtension>() {
                                 }
                             }
                             output = file
+                            break
                         }
                     }
                 }


### PR DESCRIPTION
On Windows, Rust outputs `.dll.lib`, `.dll.exp` and `.pdb` as well as `.dll`.
The last output is `.pdb` file, so `.pdb` file is copied into jar and run at runtime, then error is thrown.
I add `break` to read and copy first output into jar because first output is the `.dll` file.