### PR TITLE
Fix arguments list and environment variables list not applying

### DIFF
--- a/src/main/kotlin/fr/stardustenterprises/gradle/rust/wrapper/TargetOptions.kt
+++ b/src/main/kotlin/fr/stardustenterprises/gradle/rust/wrapper/TargetOptions.kt
@@ -83,21 +83,10 @@ data class TargetOptions(
         if (this.args.isEmpty()) {
             this.args = configuration.args
         } else {
-            if (this.args.contains("_DEFAULT")) {
-                val argsList = this.args.toList()
-                val finalList = mutableListOf<String>()
-                val index = argsList.indexOfFirst { it == "_DEFAULT" }
-                val before = argsList.subList(0, index)
-                val after = if (argsList.size == index)
-                    emptyList()
-                else
-                    argsList.subList(index + 1, argsList.size)
-
-                finalList.addAll(before)
-                finalList.addAll(configuration.args.toList())
-                finalList.addAll(after)
-
-                this.args = finalList
+            val defaultsIndex = this.args.indexOf("_DEFAULT")
+            if (defaultsIndex != -1) {
+                this.args.removeAt(defaultsIndex)
+                this.args.addAll(defaultsIndex, configuration.args)
             }
         }
 

--- a/src/main/kotlin/fr/stardustenterprises/gradle/rust/wrapper/TargetOptions.kt
+++ b/src/main/kotlin/fr/stardustenterprises/gradle/rust/wrapper/TargetOptions.kt
@@ -52,6 +52,10 @@ data class TargetOptions(
             cmd += "--release"
         }
 
+        if (!this.args.contains("_DEFAULT")) {
+            cmd.addAll(this.args)
+        }
+
         return cmd
     }
 
@@ -79,7 +83,7 @@ data class TargetOptions(
         if (this.args.isEmpty()) {
             this.args = configuration.args
         } else {
-            if (this.args.any { it == "_DEFAULT" }) {
+            if (this.args.contains("_DEFAULT")) {
                 val argsList = this.args.toList()
                 val finalList = mutableListOf<String>()
                 val index = argsList.indexOfFirst { it == "_DEFAULT" }
@@ -100,22 +104,22 @@ data class TargetOptions(
         if (this.env.isEmpty()) {
             this.env = configuration.env
         } else {
-            if (this.env.any { it.key == "_DEFAULT" }) {
-                val argsList = this.env.toList()
+            if (this.env.containsKey("_DEFAULT")) {
+                val envVarList = this.env.toList()
                 val finalList = mutableListOf<Pair<String, String>>()
-                val index = argsList.indexOfFirst { it.first == "_DEFAULT" }
-                val before = argsList.subList(0, index)
-                val after = if (argsList.size == index)
+                val index = envVarList.indexOfFirst { it.first == "_DEFAULT" }
+                val before = envVarList.subList(0, index)
+                val after = if (envVarList.size == index)
                     emptyList()
                 else
-                    argsList.subList(index + 1, argsList.size)
+                    envVarList.subList(index + 1, envVarList.size)
 
                 finalList.addAll(before)
                 finalList.addAll(configuration.env.toList())
                 finalList.addAll(after)
 
                 this.env = mutableMapOf()
-                finalList.forEach(this.env::plus)
+                finalList.toMap(this.env)
             }
         }
     }

--- a/src/main/kotlin/fr/stardustenterprises/gradle/rust/wrapper/TargetOptions.kt
+++ b/src/main/kotlin/fr/stardustenterprises/gradle/rust/wrapper/TargetOptions.kt
@@ -52,9 +52,7 @@ data class TargetOptions(
             cmd += "--release"
         }
 
-        if (!this.args.contains("_DEFAULT")) {
-            cmd.addAll(this.args)
-        }
+        cmd.addAll(this.args)
 
         return cmd
     }


### PR DESCRIPTION
This has two fixes added in one commit. The first fix was to simply make sure the arguments list actually gets added to the subcommand strings. The second fix was to the environment variable merging code, where the global vars get merged with the per-target vars. The following line:
```kotlin
finalList.forEach(this.env::plus)
```
wouldn't actually update the `this.env` variable. One fix for this could be to change `plus` to `plusAssign`, but given that `toMap` already exists which does exactly what's needed, I just changed the code to use that. It seems that `toMap` also preserves ordering.